### PR TITLE
Updated the task's makara-builder with new option syntax

### DIFF
--- a/tasks/makara-amdify.js
+++ b/tasks/makara-amdify.js
@@ -5,6 +5,10 @@ var path = require('path');
 
 module.exports = function (grunt) {
     grunt.registerTask('makara-amdify', 'Write out AMD i18n bundles', function () {
-        ma.build(this.options().appRoot || process.cwd(), this.async());
+        ma.build({
+            appRoot: this.options().appRoot || process.cwd(),
+            writer: this.async(),
+            cb: function() {}
+        });
     });
 };


### PR DESCRIPTION
This pull request builds upon the one made available [here](https://github.com/krakenjs/makara-builder/pull/5). It updates the `makara-builder` syntax with the single option parameter.

At present, this build will fail until the pull request mentioned is accepted.